### PR TITLE
スクリーニング処理を非同期実行に対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ Thumbs.db
 
 # Logs
 *.log
+app/infrastructure/claude_code/

--- a/app/domain/screening_service.py
+++ b/app/domain/screening_service.py
@@ -19,9 +19,9 @@ class ScreeningService(Protocol):
     必要なメソッドシグネチャを持っていれば自動的に準拠します。
     """
 
-    def screen(self, content: str) -> str:
+    async def screen(self, content: str) -> str:
         """
-        スクリーニング処理を実行します
+        スクリーニング処理を非同期で実行します
 
         Args:
             content: スクリーニング対象のテキスト
@@ -30,7 +30,8 @@ class ScreeningService(Protocol):
             スクリーニング結果のテキスト
 
         Note:
-            このメソッドは副作用を持たず、純粋関数として実装されるべきです。
+            このメソッドは非同期で実行され、副作用を持たず、
+            純粋関数として実装されるべきです。
         """
         ...
 

--- a/app/infrastructure/screening_service_impl.py
+++ b/app/infrastructure/screening_service_impl.py
@@ -17,9 +17,9 @@ class EchoScreeningService:
     実際のスクリーニングロジックに置き換えられる予定です。
     """
 
-    def screen(self, content: str) -> str:
+    async def screen(self, content: str) -> str:
         """
-        スクリーニング処理を実行します
+        スクリーニング処理を非同期で実行します
 
         現在の実装では、入力コンテンツを変更せずにそのまま返します。
 
@@ -31,11 +31,14 @@ class EchoScreeningService:
 
         Examples:
             >>> service = EchoScreeningService()
-            >>> service.screen("テスト文字列")
+            >>> result = await service.screen("テスト文字列")
+            >>> result
             'テスト文字列'
 
         Note:
-            この実装は副作用を持たない純粋関数です。
+            この実装は非同期で実行され、副作用を持たない純粋関数です。
+            将来的には外部APIやデータベースへの非同期アクセスを含む
+            実際のスクリーニングロジックに置き換えられる予定です。
         """
         return content
 

--- a/app/presentation/api/routes/screenings.py
+++ b/app/presentation/api/routes/screenings.py
@@ -24,17 +24,17 @@ router = APIRouter(
     "",
     response_model=ScreeningResponse,
     summary="スクリーニング実行",
-    description="提供されたコンテンツに対してスクリーニング処理を実行します。",
+    description="提供されたコンテンツに対してスクリーニング処理を非同期で実行します。",
 )
-def create_screening(
+async def create_screening(
     request: ScreeningRequest,
     usecase: ScreeningUsecase = Depends(get_screening_usecase),
 ) -> ScreeningResponse:
     """
-    スクリーニング処理を実行するエンドポイント
+    スクリーニング処理を非同期で実行するエンドポイント
 
     このエンドポイントは、リクエストボディで提供されたコンテンツに対して
-    スクリーニング処理を実行し、結果を返します。
+    スクリーニング処理を非同期で実行し、結果を返します。
 
     Args:
         request: スクリーニングリクエスト（content フィールドを含む）
@@ -63,11 +63,12 @@ def create_screening(
         ```
 
     Note:
+        非同期実行により、外部APIやデータベースアクセスを含む
+        スクリーニングロジックでも効率的に処理できます。
         現在の実装では、入力コンテンツをそのまま返す暫定的な動作です。
-        将来的には実際のスクリーニングロジックが実装される予定です。
     """
-    # ユースケースを実行してスクリーニング処理を行う
-    result_content = usecase.execute(request.content)
+    # ユースケースを非同期で実行してスクリーニング処理を行う
+    result_content = await usecase.execute(request.content)
 
     # レスポンスを作成して返す
     return ScreeningResponse(content=result_content)

--- a/app/usecase/screening_usecase.py
+++ b/app/usecase/screening_usecase.py
@@ -45,9 +45,9 @@ class ScreeningUsecase:
         """
         self._service = service
 
-    def execute(self, content: str) -> str:
+    async def execute(self, content: str) -> str:
         """
-        スクリーニング処理を実行します
+        スクリーニング処理を非同期で実行します
 
         Args:
             content: スクリーニング対象のテキスト
@@ -56,17 +56,18 @@ class ScreeningUsecase:
             スクリーニング結果のテキスト
 
         Examples:
-            >>> usecase.execute("入力テキスト")
+            >>> result = await usecase.execute("入力テキスト")
+            >>> result
             'スクリーニング結果'
 
         Note:
             このメソッドは、ScreeningServiceのscreen()メソッドを
-            呼び出してスクリーニング処理を実行します。
+            非同期で呼び出してスクリーニング処理を実行します。
             現在の実装では追加のビジネスロジックはありませんが、
             将来的にロギング、バリデーション、前処理・後処理などを
             追加する拡張ポイントとなります。
         """
-        return self._service.screen(content)
+        return await self._service.screen(content)
 
 
 __all__ = ["ScreeningUsecase"]


### PR DESCRIPTION
## 概要

すべての層のスクリーニング処理を非同期（async/await）に変更しました。

## 変更したファイル

### 1. Domain層
**app/domain/screening_service.py**
```python
# 変更前
def screen(self, content: str) -> str:
    ...

# 変更後
async def screen(self, content: str) -> str:
    ...
```

### 2. Infrastructure層
**app/infrastructure/screening_service_impl.py**
```python
# 変更前
def screen(self, content: str) -> str:
    return content

# 変更後
async def screen(self, content: str) -> str:
    return content
```

### 3. Application層
**app/usecase/screening_usecase.py**
```python
# 変更前
def execute(self, content: str) -> str:
    return self._service.screen(content)

# 変更後
async def execute(self, content: str) -> str:
    return await self._service.screen(content)
```

### 4. Presentation層
**app/presentation/api/routes/screenings.py**
```python
# 変更前
def create_screening(...) -> ScreeningResponse:
    result_content = usecase.execute(request.content)
    return ScreeningResponse(content=result_content)

# 変更後
async def create_screening(...) -> ScreeningResponse:
    result_content = await usecase.execute(request.content)
    return ScreeningResponse(content=result_content)
```

## 利点

### 1. パフォーマンス向上 ⚡
- **並行処理**: 複数のリクエストを同時に処理可能
- **効率的なI/O**: I/O待機中に他のリクエストを処理
- **スケーラビリティ**: より多くの同時接続を処理可能

### 2. 将来の拡張性 🚀
- 外部APIへの非同期呼び出し（OpenAI API、Azure Cognitive Servicesなど）
- データベースへの非同期アクセス（asyncpg、motor など）
- 複数のスクリーニングサービスの並行実行
- 長時間実行される処理でも他のリクエストをブロックしない

### 3. FastAPIとの親和性 🎯
- FastAPIは非同期エンドポイントを最適化
- uvicornの非同期ワーカーを効率的に活用
- Pythonの標準的な非同期パターンに準拠

## 動作確認

### サーバー起動
```bash
uv run --no-sync uvicorn app.presentation.main:app --reload
```

### APIテスト
```bash
# スクリーニングエンドポイント
curl -X POST http://localhost:8000/v1/screenings \
  -H "Content-Type: application/json" \
  -d '{"content":"非同期テスト"}'
# → {"content":"非同期テスト"} ✅

# ヘルスチェック
curl http://localhost:8000/health
# → {"status":"ok"} ✅
```

## 後方互換性

✅ **既存のクライアントコードは変更不要**
- FastAPIが同期/非同期を透過的に処理
- APIのインターフェースは変更なし
- レスポンス形式も同じ

## 将来の実装例

非同期処理を活用した実装例：

```python
# 外部API呼び出し
async def screen(self, content: str) -> str:
    async with httpx.AsyncClient() as client:
        response = await client.post(
            "https://api.openai.com/v1/...",
            json={"content": content}
        )
        return response.json()["result"]

# 複数サービスの並行実行
async def screen(self, content: str) -> str:
    results = await asyncio.gather(
        service1.screen(content),
        service2.screen(content),
        service3.screen(content),
    )
    return combine_results(results)
```

## その他の変更

- `.gitignore`: `app/infrastructure/claude_code/` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)